### PR TITLE
Remote first approach to take benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
-/logs
+/logs*
 .env*

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ For each benchmark, we recommend using a new Galaxy container to ensure a clean 
 
 The apps are deployed to Galaxy to benefit of further analysis with MontiAPM tool.
 
+To enable MontiAPM, use `ENABLE_APM`. MontiAPM may overload the app, so measure the metrics carefully, especially during CPU profiling. Enable or disable it in both apps for a fair comparison.
+
 To deploy each app after changes:
 
 ```shell

--- a/artillery/reactive-stress-remote.yml
+++ b/artillery/reactive-stress-remote.yml
@@ -1,8 +1,8 @@
 config:
   target: http://localhost:3000
   phases:
-    - duration: 30
-      arrivalRate: 1
+    - duration: 60
+      arrivalRate: 2
       name: Warm up
   ensure:
     maxErrorRate: 1
@@ -12,7 +12,7 @@ config:
     playwright:
       globalTimeout: 240000
       launchOptions:
-        slowMo: 2500
+        slowMo: 500
   # Path to JavaScript file that defines Playwright test functions
   processor: '../tests/test-helpers.js'
 scenarios:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,7 +16,9 @@ appPort=3000
 # Ensure proper cleanup on interrupt the process
 function cleanup() {
     builtin cd "${appPath}"
-    METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor remove apm-agent
+    if [[ -n "${ENABLE_APM}" ]]; then
+      METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor remove apm-agent
+    fi
     builtin cd ${baseDir};
     exit 0
 }
@@ -25,7 +27,9 @@ trap cleanup SIGINT SIGTERM
 # Prepare, run and wait meteor app
 builtin cd "${appPath}"
 
-METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor add apm-agent
+if [[ -n "${ENABLE_APM}" ]]; then
+  METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor add apm-agent
+fi
 
 rm -rf "${appPath}/.meteor/local"
 hostname="${app//x/0}-perf.meteorapp.com"

--- a/scripts/helpers/monitor-remote-cpu-ram.js
+++ b/scripts/helpers/monitor-remote-cpu-ram.js
@@ -1,0 +1,93 @@
+const https = require('https');
+
+// Function to fetch data from the API
+function fetchData() {
+    return new Promise((resolve, reject) => {
+        const requestBody = JSON.stringify({
+            token: process.env.GALAXY_TOKEN,
+            hostname: process.env.GALAXY_APP,
+            region: "us-east-1",
+            seriesName: "5s",
+        });
+
+        const options = {
+            hostname: 'galaxy-beta.meteor.com',
+            path: '/api/container-metrics',
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(requestBody),
+            },
+        };
+
+        const req = https.request(options, (res) => {
+            let responseBody = '';
+
+            // Collect response data
+            res.on('data', (chunk) => {
+                responseBody += chunk;
+            });
+
+            // Handle the end of the response
+            res.on('end', () => {
+                try {
+                    const jsonResponse = JSON.parse(responseBody);
+                    resolve(jsonResponse);
+                } catch (error) {
+                    reject(new Error('Error parsing JSON response: ' + error));
+                }
+            });
+        });
+
+        // Handle request errors
+        req.on('error', (error) => {
+            reject(new Error('Request failed: ' + error));
+        });
+
+        // Write the request body
+        req.write(requestBody);
+        req.end();
+    });
+}
+
+// Function to calculate averages
+function calculateAverages(data) {
+    const connectionsData = data[0].connections;
+    const cpuData = data[0].cpu;
+    const memoryData = data[0].memory;
+
+    // Calculate average connections
+    const totalConnections = connectionsData.reduce((acc, conn) => acc + conn.connections, 0);
+    const averageConnections = totalConnections / connectionsData.length;
+
+    // Calculate average CPU percentage
+    const totalCpuPercentage = cpuData.reduce((acc, cpu) => acc + cpu.percentage, 0);
+    const averageCpuPercentage = totalCpuPercentage / cpuData.length;
+
+    // Calculate average memory usage
+    const totalMemoryUsage = memoryData.reduce((acc, mem) => acc + mem.value, 0);
+    const averageMemoryUsage = totalMemoryUsage / memoryData.length;
+
+    return {
+        averageConnections,
+        averageCpuPercentage,
+        averageMemoryUsage,
+    };
+}
+
+// Main function to execute the script
+async function main() {
+    try {
+        const data = await fetchData();
+        const averages = calculateAverages(data);
+
+        console.log('---- Galaxy Container metrics ----');
+        console.log('Average CPU Percentage:', averages.averageCpuPercentage);
+        console.log('Average Memory Usage:', averages.averageMemoryUsage);
+
+    } catch (error) {
+        console.error('Error fetching data:', error);
+    }
+}
+
+main();

--- a/scripts/monitor-remote.sh
+++ b/scripts/monitor-remote.sh
@@ -11,8 +11,9 @@ if [[ -z "$app" ]] || [[ -z "$script" ]]; then
 fi
 
 # Redirect stdout (1) and stderr (2) to a file
+logFile="logs/${logName}-${app}-${script}.log"
 mkdir -p logs
-exec > ./logs/${logName}-${app}-${script}.log 2>&1
+exec > "./${logFile}" 2>&1
 
 # Initialize script constants
 baseDir="${PWD}"
@@ -56,9 +57,28 @@ function isRunningUrl() {
 
 # Ensure proper cleanup on interrupt the process
 function cleanup() {
+    verify="${1}"
+
+    # Verify valid output
+    if [[ "${verify}" == "true" ]]; then
+      sleep 6
+      if cat "${baseDir}/${logFile}" | grep -q "Timeout"; then
+        echo -e "${RED}*** !!! ERROR: SOMETHING WENT WRONG !!! ***${NC}"
+        echo -e "${RED}Output triggered an unexpected timeout (${logFile})${NC}"
+        echo -e "${RED} Galaxy container is overloaded and unable to provide accurate comparison results.${NC}"
+        echo -e "${RED} Try switching to a configuration that Galaxy container can handle.${NC}"
+
+        exit 1
+      else
+        echo -e "${GREEN}Output is suitable for comparisons (${logFile})${NC}"
+        echo -e "${GREEN} Galaxy container managed the configuration correctly.${NC}"
+
+        exit 0
+      fi
+    fi
+
     builtin cd ${baseDir};
     # Kill all background processes
-    # pkill -P ${artPid}
     pkill -P $$
     exit 0
 }
@@ -97,4 +117,5 @@ artPid="$!"
 
 # Wait for artillery script to finish the process
 wait "${artPid}"
-cleanup
+
+cleanup "true"

--- a/scripts/monitor-remote.sh
+++ b/scripts/monitor-remote.sh
@@ -130,6 +130,7 @@ db.getCollectionNames().forEach(function(collectionName) {
 });
 EOF
 
+galaxyAppHost=$(echo "$REMOTE_URL" | sed 's/^https\?:\/\///')
 galaxyAppId="$(getGalaxyAppId)"
 # Prepare Galaxy container
 if [[ -z "${SKIP_KILL_CONTAINERS}" ]] && [[ -n "${GALAXY_API_KEY}" ]] && [[ -n "${galaxyAppId}" ]]; then
@@ -146,7 +147,7 @@ if [[ -z "${SKIP_KILL_CONTAINERS}" ]] && [[ -n "${GALAXY_API_KEY}" ]] && [[ -n "
       -X POST \
       -H "Content-Type: application/json" \
       -H "galaxy-api-key: ${GALAXY_API_KEY}" \
-      --data "{\"query\": \"{ app(hostname: \\\"$(echo "$REMOTE_URL" | sed 's/^https\?:\/\///')\\\") { _id containers { _id } } }\"}" \
+      --data "{\"query\": \"{ app(hostname: \\\"${galaxyAppHost}\\\") { _id containers { _id } } }\"}" \
       https://us-east-1.api.meteor.com/graphql | jq -c '.data.app.containers[]'
     )"
     # Iterate over containers
@@ -179,5 +180,7 @@ artPid="$!"
 
 # Wait for artillery script to finish the process
 wait "${artPid}"
+
+GALAXY_APP="${galaxyAppHost}" node ./scripts/helpers/monitor-remote-cpu-ram.js
 
 cleanup "true"

--- a/scripts/monitor-remote.sh
+++ b/scripts/monitor-remote.sh
@@ -49,6 +49,10 @@ function getRemoteUrl() {
   echo "$(eval "echo \${REMOTE_URL_$(formatToEnv ${app})}")"
 }
 
+function getGalaxyAppId() {
+  echo "$(eval "echo \${GALAXY_$(formatToEnv ${app})_APPID}")"
+}
+
 function isRunningUrl() {
   local url="${1}"
   local urlStatus="$(curl -Is "${url}" | head -1)"
@@ -99,12 +103,68 @@ if [[ -z "${REMOTE_URL}" ]]; then
   exit 1;
 fi
 
+function waitRunningApp() {
+  echo "Waiting \"${REMOTE_URL}\""
+  local waitTimeoutSecs=$((900000 / 1000))
+  local waitSecs=0
+  while ! isRunningUrl "${REMOTE_URL}" && [[ "${waitSecs}" -lt "${waitTimeoutSecs}" ]]; do
+    sleep 1
+    waitSecs=$((waitSecs + 1))
+  done
+}
+
+function waitStoppedApp() {
+  echo "Stopping \"${REMOTE_URL}\""
+  local waitTimeoutSecs=$((900000 / 1000))
+  local waitSecs=0
+  while isRunningUrl "${REMOTE_URL}" && [[ "${waitSecs}" -lt "${waitTimeoutSecs}" ]]; do
+    sleep 1
+    waitSecs=$((waitSecs + 1))
+  done
+}
+
 # Cleaning the collection from production first
 npx m mongo "${MONGO_VERSION}" "${mongoUrl}" --ssl --sslAllowInvalidCertificates <<EOF
 db.getCollectionNames().forEach(function(collectionName) {
    db[collectionName].deleteMany({});
 });
 EOF
+
+galaxyAppId="$(getGalaxyAppId)"
+# Prepare Galaxy container
+if [[ -z "${SKIP_KILL_CONTAINERS}" ]] && [[ -n "${GALAXY_API_KEY}" ]] && [[ -n "${galaxyAppId}" ]]; then
+  if ! isRunningUrl "${REMOTE_URL}"; then
+    echo "Start app ${REMOTE_URL} ${galaxyAppId}"
+    curl -s \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -H "galaxy-api-key: ${GALAXY_API_KEY}" \
+      --data "{\"query\": \"mutation { startApp(appId: \\\"${galaxyAppId}\\\") { _id } }\"}" \
+      https://us-east-1.api.meteor.com/graphql
+  else
+    containers="$(curl -s \
+      -X POST \
+      -H "Content-Type: application/json" \
+      -H "galaxy-api-key: ${GALAXY_API_KEY}" \
+      --data "{\"query\": \"{ app(hostname: \\\"$(echo "$REMOTE_URL" | sed 's/^https\?:\/\///')\\\") { _id containers { _id } } }\"}" \
+      https://us-east-1.api.meteor.com/graphql | jq -c '.data.app.containers[]'
+    )"
+    # Iterate over containers
+    for container in ${containers}; do
+      container_id=$(echo "${container}" | jq -r '._id')  # Extract container ID
+      echo "Kill container: ${container_id}"  # Do something with the container ID
+      curl -s \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -H "galaxy-api-key: ${GALAXY_API_KEY}" \
+        --data "{\"query\": \"mutation { killContainer(appId: \\\"${galaxyAppId}\\\", containerId: \\\"${container_id}\\\") { _id } }\"}" \
+        https://us-east-1.api.meteor.com/graphql
+    done
+    waitStoppedApp
+  fi
+
+  waitRunningApp
+fi
 
 if ! isRunningUrl "${REMOTE_URL}"; then
   echo "No app running at ${REMOTE_URL}"

--- a/scripts/monitor-remote.sh
+++ b/scripts/monitor-remote.sh
@@ -164,6 +164,8 @@ if [[ -z "${SKIP_KILL_CONTAINERS}" ]] && [[ -n "${GALAXY_API_KEY}" ]] && [[ -n "
   fi
 
   waitRunningApp
+
+  sleep 10
 fi
 
 if ! isRunningUrl "${REMOTE_URL}"; then

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -52,6 +52,11 @@ function waitMeteorApp() {
 function cleanup() {
     verify="${1}"
 
+    builtin cd ${baseDir};
+    # Kill all background processes
+    pkill -P ${artPid}
+    pkill -P $$
+
     # Verify valid output
     if [[ "${verify}" == "true" ]]; then
       sleep 6
@@ -70,10 +75,6 @@ function cleanup() {
       fi
     fi
 
-    builtin cd ${baseDir};
-    # Kill all background processes
-    pkill -P ${artPid}
-    pkill -P $$
     exit 0
 }
 trap cleanup SIGINT SIGTERM

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -51,15 +51,11 @@ function waitMeteorApp() {
 # Ensure proper cleanup on interrupt the process
 function cleanup() {
     verify="${1}"
-    builtin cd ${baseDir};
-    # Kill all background processes
-    pkill -P ${artPid}
-    pkill -P $$
-    sleep 6
 
     # Verify valid output
     if [[ "${verify}" == "true" ]]; then
-      if cat "${baseDir}/${logFile}" | grep -q "TimeoutError"; then
+      sleep 6
+      if cat "${baseDir}/${logFile}" | grep -q "Timeout"; then
         echo -e "${RED}*** !!! ERROR: SOMETHING WENT WRONG !!! ***${NC}"
         echo -e "${RED}Output triggered an unexpected timeout (${logFile})${NC}"
         echo -e "${RED} Your machine is overloaded and unable to provide accurate comparison results.${NC}"
@@ -73,6 +69,11 @@ function cleanup() {
         exit 0
       fi
     fi
+
+    builtin cd ${baseDir};
+    # Kill all background processes
+    pkill -P ${artPid}
+    pkill -P $$
     exit 0
 }
 trap cleanup SIGINT SIGTERM

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -64,7 +64,7 @@ function logMeteorVersion() {
     echo -e " Meteor checkout version - $(git rev-parse HEAD)"
     builtin cd "${oldPath}"
   else
-    echo -e " Meteor version - $(meteor --version)"
+    echo -e " Meteor version - $(cat .meteor/release)"
   fi
   echo -e "==============================="
 }

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -59,7 +59,10 @@ function logScriptConfig() {
 function logMeteorVersion() {
   echo -e "==============================="
   if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
+    local oldPath="${PWD}"
+    builtin cd "${METEOR_CHECKOUT_PATH}"
     echo -e " Meteor checkout version - $(git rev-parse HEAD)"
+    builtin cd "${oldPath}"
   else
     echo -e " Meteor version - $(meteor --version)"
   fi

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -48,6 +48,24 @@ function waitMeteorApp() {
   done
 }
 
+function logScriptConfig() {
+  echo -e "==============================="
+  echo -e " Artillery Configuration - $(date) "
+  echo -e "==============================="
+  cat "${baseDir}/artillery/${script}"
+  echo -e "==============================="
+}
+
+function logMeteorVersion() {
+  echo -e "==============================="
+  if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
+    echo -e " Meteor checkout version - $(git rev-parse HEAD)"
+  else
+    echo -e " Meteor version - $(meteor --version)"
+  fi
+  echo -e "==============================="
+}
+
 # Ensure proper cleanup on interrupt the process
 function cleanup() {
     verify="${1}"
@@ -79,9 +97,12 @@ function cleanup() {
 }
 trap cleanup SIGINT SIGTERM
 
+logScriptConfig
+
 # Prepare, run and wait meteor app
 builtin cd "${appPath}"
 rm -rf "${appPath}/.meteor/local"
+logMeteorVersion
 if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
   METEOR_PACKAGE_DIRS="${baseDir}/packages" ${METEOR_CHECKOUT_PATH}/meteor run --port ${appPort} &
 else


### PR DESCRIPTION
OSS-585

The PR is to start using the Galaxy container as the approach to measure performance (only for Meteor staff since we have access to the Galaxy apps involving this repository).

This PR is also a preparation of a proper artillery config that reproduces the regressions found as an action to address community’s feedback [on this thread](https://forums.meteor.com/t/meteor-3-performance-wins-challenges-and-the-path-forward/62253).

If we have this configuration done, other members of the community can also use their infrastructures to deploy the apps and use the script and configuration to compare Meteor 3 and 2 and provide feedback and performance improvements.

The inital approach was using a local-first approach with a fixed machine. It had 64GB of RAM (software capped this memory at its limit), and we noticed the issue reported: Meteor 3 performs worse than Meteor 2, with methods running faster and subscriptions being the slowest. Testing with a remote machine confirmed this behavior, and later we gathered more metrics using APM here. Shifting to a remote-first approach would better align results with the Meteor team and community.