### PR TITLE
Implement script monitor for bundler process

### DIFF
--- a/BUNDLER.md
+++ b/BUNDLER.md
@@ -1,0 +1,32 @@
+# Meteor bundler
+
+## How
+
+### Running locally
+
+To run a Meteor profile of the bundling process of your app on your machine:
+
+```shell
+./scripts/monitor-bundler.sh <app> <log-context>
+```
+
+- `<app>`: The app folder name within `./apps` to profile, or the absolute path to any Meteor app.
+- `<log-context>`: A name to prefix the logs generated within `./logs`.
+
+You can analyze performance using a Meteor checkout. This helps measure the impact of changes and ensures performance stays consistent or improves.
+
+```shell
+METEOR_CHECKOUT_PATH=<path-to-meteor-checkout> ./scripts/monitor-bundler.sh <app> <log-context>
+```
+
+Set `METEOR_BUNDLE_SIZE=true` to gather bundle size data and assess changes in build size.
+
+Use `METEOR_IDLE_TIMEOUT=<seconds>` to set a profiling timeout. The default (90s) is usually enough for each build step. If you get errors from early exits, adjust this value.
+
+> Starting with Meteor 3.2, this script is included in the CLI. If you're using this version, run `meteor profile` to get a performance report. The same environment variables apply.
+
+## Benchmarks
+
+### Meteor 2.16 vs 3.2
+
+#### TODO

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-This repository is the base to measure performance between Meteor 2 and Meteor 3. It serves as a comparison point for various functionalities and helps catch any performance regressions.
+This repository is the base to measure performance between Meteor 2 and Meteor 3, focusing on runtime and development experience with its bundler. It serves as a comparison point for various functionalities and helps catch any performance regressions.
 
 This repository can inspire you to adapt the scripts and analyze performance in your applications. We're here to make the process easier, so feel free to share any feedback.
 
@@ -12,7 +12,7 @@ This repository includes:
 
 - Meteor applications for Meteor 2 and 3 to test performance, located in the `./apps` folder.
 - Meteor packages for shared and isomorphic code, found in the `./packages` folder.
-- Playwright tests to perform actions against the apps, found in `./tests`.
+- Playwright tests to perform actions against the apps for runtime testing , found in `./tests`.
 - Artillery configurations for stress testing your server, found in `./artillery`.
 - Scripts to monitor performance and log results, found in `./scripts`.
 - Logs from local monitoring runs, found in `./logs`.
@@ -23,86 +23,14 @@ This repository includes:
 - Unix System
 - Node 20.x version
 
-## How
+## Usage
 
-### Running locally
+Scripts are available to benchmark both runtime and bundler performance.
 
-To run a stress test on your machine:
+### Meteor runtime
 
-```shell
-npm install
-./scripts/monitor.sh <app> <artillery-script> <log-context>
-```
+Learn more of this process at [how to benchmark Meteor runtime](./RUNTIME.md).
 
-- `<app>`: The app folder name within `./apps` to stress test.
-- `<artillery-script>`: The artillery configuration within `./artillery`.
-- `<log-context>`: A name to prefix the logs generated within `./logs`.
+### Meteor bundler
 
-The process will take some time, and the logs are updated live at `./logs`.
-
-Your machine might struggle with the default artillery configuration, but it should still reveal performance differences between the tests. Adjust the configuration as needed by learning from [artillery.io options](https://www.artillery.io/docs).
-
-You can analyze performance using a Meteor checkout. This allows you to quickly measure the impact of ongoing changes and ensure consistent or improved performance.
-
-```shell
-METEOR_CHECKOUT_PATH=<path-to-meteor-checkout> ./scripts/monitor.sh <app> <artillery-script> <log-context>
-```
-
-### Running remotely
-
-> Currently, only Meteor staff can fully manage the entire process for the tasks app.
-
-To run a stress test on a galaxy server:
-
-- Prepare a new application container on Galaxy
-- Prepare secrets on `.env.prod` file
-  - `MONGO_URL_TASKS_3_X` and `MONGO_URL_TASKS_2_X`. Url to connect to the MongoDB instance for each application.
-  - `MONGO_VERSION` Version of MongoDB used to pre-clean your environment
-  - `REMOTE_URL_TASKS_3_X` `REMOTE_URL_TASKS_2_X`. Public endpoint to connect to your application.
-
-Run the following monitoring command to start benchmarking:
-
-```shell
-npm install
-./scripts/monitor-remote.sh <app> <artillery-script> <log-context>
-```
-
-This will set up the remote context needed to run the playwright script.
-
-Remote stress testing helps gather extra metrics from MontiAPM for deeper performance analysis.
-
-For each benchmark, we recommend using a new Galaxy container to ensure a clean environment, preventing any interference with your performance results.
-
-### Deploy
-
-The apps are deployed to Galaxy to benefit of further analysis with MontiAPM tool.
-
-To enable MontiAPM, use `ENABLE_APM`. MontiAPM may overload the app, so measure the metrics carefully, especially during CPU profiling. Enable or disable it in both apps for a fair comparison.
-
-To deploy each app after changes:
-
-```shell
-./scripts/deploy.sh <app>
-```
-
-Current apps are accessible at:
-
-- tasks-2.x: http://tasks-2.0-perf.meteorapp.com
-- tasks-3.x: http://tasks-3.0-perf.meteorapp.com
-
-
-## Benchmarks
-
-### Meteor 2.16 vs 3.1.1
-
-Meteor **3.1.1** is in average **~28% faster**, uses **~51% less CPU** and **~17% less of RAM** in a **reactive scenario**.
-
-Meteor **3.1.1** is in average **~19% faster**, uses **~28,82% more CPU** and **~27% more of RAM** in a **non-reactive scenario**.
-
-More details on this benchmark can be found at [`./benchmarks/meteor2.16-vs-3.1.1`](./benchmarks/meteor2.16-vs-3.1.1).
-
-## Challenge ahead
-
-Performance is an ongoing effort that requires continuous attention. The performance suite helps detect regressions and uncover improvements in future Meteor versions.
-
-Performance is highly variable and depends on your use case coverage. Looking ahead, we aim to develop a more real benchmarking process. This would test additional Meteor scenarios (like having more observers, collections and subscriptions) while incorporating widely used community packages from real-world applications (publish-composite, redis-oplog, apm, etc).
+Learn more of this process at [how to benchmark Meteor bundler](./BUNDLER.md).

--- a/RUNTIME.md
+++ b/RUNTIME.md
@@ -1,0 +1,85 @@
+# Meteor runtime
+
+## How
+
+### Running locally
+
+To run a stress test on your machine:
+
+```shell
+npm install
+./scripts/monitor.sh <app> <artillery-script> <log-context>
+```
+
+- `<app>`: The app folder name within `./apps` to stress test.
+- `<artillery-script>`: The artillery configuration within `./artillery`.
+- `<log-context>`: A name to prefix the logs generated within `./logs`.
+
+The process will take some time, and the logs are updated live at `./logs`.
+
+Your machine might struggle with the default artillery configuration, but it should still reveal performance differences between the tests. Adjust the configuration as needed by learning from [artillery.io options](https://www.artillery.io/docs).
+
+You can analyze performance using a Meteor checkout. This allows you to quickly measure the impact of ongoing changes and ensure consistent or improved performance.
+
+```shell
+METEOR_CHECKOUT_PATH=<path-to-meteor-checkout> ./scripts/monitor.sh <app> <artillery-script> <log-context>
+```
+
+### Running remotely
+
+> Currently, only Meteor staff can fully manage the entire process for the tasks app.
+
+To run a stress test on a galaxy server:
+
+- Prepare a new application container on Galaxy
+- Prepare secrets on `.env.prod` file
+    - `MONGO_URL_TASKS_3_X` and `MONGO_URL_TASKS_2_X`. Url to connect to the MongoDB instance for each application.
+    - `MONGO_VERSION` Version of MongoDB used to pre-clean your environment
+    - `REMOTE_URL_TASKS_3_X` `REMOTE_URL_TASKS_2_X`. Public endpoint to connect to your application.
+
+Run the following monitoring command to start benchmarking:
+
+```shell
+npm install
+./scripts/monitor-remote.sh <app> <artillery-script> <log-context>
+```
+
+This will set up the remote context needed to run the playwright script.
+
+Remote stress testing helps gather extra metrics from MontiAPM for deeper performance analysis.
+
+For each benchmark, we recommend using a new Galaxy container to ensure a clean environment, preventing any interference with your performance results.
+
+### Deploy
+
+The apps are deployed to Galaxy to benefit of further analysis with MontiAPM tool.
+
+To enable MontiAPM, use `ENABLE_APM`. MontiAPM may overload the app, so measure the metrics carefully, especially during CPU profiling. Enable or disable it in both apps for a fair comparison.
+
+To deploy each app after changes:
+
+```shell
+./scripts/deploy.sh <app>
+```
+
+Current apps are accessible at:
+
+- tasks-2.x: http://tasks-2.0-perf.meteorapp.com
+- tasks-3.x: http://tasks-3.0-perf.meteorapp.com
+
+
+## Benchmarks
+
+### Meteor 2.16 vs 3.1.1
+
+Meteor **3.1.1** is in average **~28% faster**, uses **~51% less CPU** and **~17% less of RAM** in a **reactive scenario**.
+
+Meteor **3.1.1** is in average **~19% faster**, uses **~28,82% more CPU** and **~27% more of RAM** in a **non-reactive scenario**.
+
+More details on this benchmark can be found at [`./benchmarks/meteor2.16-vs-3.1.1`](./benchmarks/meteor2.16-vs-3.1.1).
+
+## Challenge ahead
+
+Performance is an ongoing effort that requires continuous attention. The performance suite helps detect regressions and uncover improvements in future Meteor versions.
+
+Performance is highly variable and depends on your use case coverage. Looking ahead, we aim to develop a more real benchmarking process. This would test additional Meteor scenarios (like having more observers, collections and subscriptions) while incorporating widely used community packages from real-world applications (publish-composite, redis-oplog, apm, etc).

--- a/scripts/helpers/get-meteor-entrypoint.js
+++ b/scripts/helpers/get-meteor-entrypoint.js
@@ -3,7 +3,9 @@ const fs = require('fs');
 function getMeteorEntrypoint(appPath, clientOrServer = 'client') {
   const rawData = fs.readFileSync(`${appPath}/package.json`);
   const jsonData = JSON.parse(rawData);
-  return `${appPath}/${jsonData?.meteor?.mainModule?.[clientOrServer]}`;
+  const entrypoint = jsonData?.meteor?.mainModule?.[clientOrServer];
+  if (!entrypoint) return '';
+  return `${appPath}/${entrypoint}`;
 }
 
 // Check if script is run directly

--- a/scripts/helpers/get-meteor-entrypoint.js
+++ b/scripts/helpers/get-meteor-entrypoint.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+function getMeteorEntrypoint(appPath, clientOrServer = 'client') {
+  const rawData = fs.readFileSync(`${appPath}/package.json`);
+  const jsonData = JSON.parse(rawData);
+  return `${appPath}/${jsonData?.meteor?.mainModule?.[clientOrServer]}`;
+}
+
+// Check if script is run directly
+if (require.main === module) {
+  const appPath = process.argv[2];
+  const clientOrServer = process.argv[3] || 'client';
+  console.log(getMeteorEntrypoint(appPath, clientOrServer));
+}
+
+// Export the function for external execution
+module.exports = getMeteorEntrypoint;

--- a/scripts/helpers/print-bundle-size.js
+++ b/scripts/helpers/print-bundle-size.js
@@ -1,0 +1,91 @@
+function calculateSize(node) {
+  let totalSize = 0;
+  let packageSizes = [];
+
+  // If the node is a package and hasn't been visited, calculate its size
+  if (node.size) {
+    totalSize += node.size;
+  }
+
+  // If the node has children, process each child
+  if (node.children && node.children.length > 0) {
+    for (let child of node.children) {
+      const { totalSize: childSize, packageSizes: childPackageSizes } = calculateSize(child);
+
+      // Add the child's size to the total size
+      totalSize += childSize;
+
+      // Append the package sizes from this child
+      packageSizes.push(...childPackageSizes);
+    }
+  }
+
+  if (node.type === 'package') {
+    packageSizes.push(`- Total ${node.name} size: ${totalSize}`);
+  }
+
+  return { totalSize, packageSizes };
+}
+
+function processRoot(node) {
+  if (node.children && node.children.length > 0) {
+    for (let child of node.children) {
+      if (child.type === 'bundle') {
+        // Calculate the size of each "bundle" and print its total size
+        const { totalSize: childSize, packageSizes } = calculateSize(child);
+
+        console.log(`Total ${child.name} size: ${childSize} (${(childSize / 1000 / 1000).toFixed(2)} MB)`);
+
+        // Print the breakdown of package sizes under this bundle
+        packageSizes.forEach(size => console.log(size));
+      }
+    }
+  }
+}
+
+const https = require('https');
+const http = require('http');
+
+function fetchData() {
+  return new Promise((resolve, reject) => {
+    const url = process.env.MONITOR_SIZE_URL;
+    const protocol = url.startsWith('https') ? https : http; // Check if URL starts with https
+
+    const req = protocol.request(url, (res) => {
+      let responseBody = '';
+
+      // Collect response data
+      res.on('data', (chunk) => {
+        responseBody += chunk;
+      });
+
+      // Handle the end of the response
+      res.on('end', () => {
+        try {
+          const jsonResponse = JSON.parse(responseBody);
+          resolve(jsonResponse);
+        } catch (error) {
+          reject(new Error('Error parsing JSON response: ' + error));
+        }
+      });
+    });
+
+    // Handle request errors
+    req.on('error', (error) => {
+      reject(new Error('Request failed: ' + error));
+    });
+
+    req.end();
+  });
+}
+
+async function main() {
+  try {
+    const data = await fetchData();
+    processRoot(data);
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
+}
+
+main();

--- a/scripts/helpers/print-meteor-packages.js
+++ b/scripts/helpers/print-meteor-packages.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+
+const columns = 4;
+
+function toMatrix(arr, columns) {
+  let matrix = [];
+  for (let i = 0; i < arr.length; i += columns) {
+    matrix.push(arr.slice(i, i + columns));
+  }
+  return matrix;
+}
+
+function readFileLinesSync(filePath) {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8'); // Read file synchronously
+    return data.split(/\r?\n/).filter(Boolean).filter(line => !line.startsWith('#')); // Split into an array of lines (handles both \n and \r\n)
+  } catch (err) {
+    console.error("Error reading file:", err);
+    return [];
+  }
+}
+
+function printMeteorAtmospherePackages(appPath) {
+  const atmsData = readFileLinesSync(`${appPath}/.meteor/versions`);
+
+  const atmsPackages = atmsData;
+  const atmsMatrix = toMatrix(atmsPackages, columns);
+  console.log("\n☄️  Atmosphere\n");
+  if (atmsMatrix.length) {
+    console.table(atmsMatrix);
+  } else {
+    console.log("No found\n");
+  }
+}
+
+function printMeteorNpmPackages(appPath) {
+  const rawData = fs.readFileSync(`${appPath}/package.json`);
+  const jsonData = JSON.parse(rawData);
+
+  const depPackages = Object.entries(Object.assign({}, jsonData.dependencies)).map(([k, v]) => `${k}@${v}`);
+  const depMatrix = toMatrix(depPackages, columns);
+  console.log("\n📦️  Dependencies\n");
+  if (depMatrix.length) {
+    console.table(depMatrix);
+  } else {
+    console.log("No found\n");
+  }
+
+  const devPackages = Object.entries(Object.assign({}, jsonData.devDependencies)).map(([k, v]) => `${k}@${v}`);
+  const devMatrix = toMatrix(devPackages, columns);
+  console.log("\n🛠️  DevDependencies\n");
+  if (devMatrix.length) {
+    console.table(devMatrix);
+  } else {
+    console.log("No found\n");
+  }
+}
+
+function printMeteorPackages(appPath, npmOrAtmosphere = 'npm') {
+  if (npmOrAtmosphere === 'npm') {
+    printMeteorNpmPackages(appPath);
+  } else {
+    printMeteorAtmospherePackages(appPath);
+  }
+}
+
+// Check if script is run directly
+if (require.main === module) {
+  const appPath = process.argv[2];
+  const npmOrAtmosphere = process.argv[3] || 'npm';
+  printMeteorPackages(appPath, npmOrAtmosphere);
+}
+
+// Export the function for external execution
+module.exports = printMeteorPackages;

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -291,7 +291,7 @@ function isOSX() {
 
 function getTime() {
   if isOSX; then
-    date +%s
+    echo $(date +%s)000
   else
     date +%s%3N
   fi

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -305,7 +305,7 @@ function isOSX() {
 }
 
 function getTime() {
-  $(getMeteorNodeCmd) -e "console.log(new Date().getTime())"
+  $(getMeteorNodeCmd) -e "console.log(String(Date.now()).trim())"
 }
 
 function findSecondPattern() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -150,6 +150,10 @@ function formatToEnv() {
   echo "${str}"
 }
 
+function sedi() {
+  sed --version >/dev/null 2>&1 && sed -i -- "$@" || sed -i "" "$@"
+}
+
 function isRunningUrl() {
   local url="${1}"
   local urlStatus="$(curl -Is "${url}" | head -1)"
@@ -216,7 +220,7 @@ function visualizeMeteorAppBundle() {
 
 function removeMeteorAppBundleVisualizer() {
   METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} remove bundle-visualizer
-  sed -i '/bundle-visualizer/d' "${appPath}/.meteor/versions"
+  sedi '/bundle-visualizer/d' "${appPath}/.meteor/versions"
 }
 
 function runScriptHelper() {
@@ -406,7 +410,7 @@ function appendLine() {
 }
 
 function removeLastLine() {
-    sed -i '$ d' "$1"
+    sedi '$ d' "$1"
 }
 
 function formatFile() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -508,7 +508,7 @@ logScriptInfo
 logMeteorVersion
 killProcessByPort "${appPort}"
 
-logProgress "Profiling \"Cold start\"..."
+logProgress " * Profiling \"Cold start\"..."
 
 logMessage "==============================="
 logMessage "[Cold start]"
@@ -523,7 +523,7 @@ ColdStartProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
-logProgress "Profiling \"Cache start\"..."
+logProgress " * Profiling \"Cache start\"..."
 
 logMessage "==============================="
 logMessage "[Cache start]"
@@ -537,7 +537,7 @@ CacheStartProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
-logProgress "Profiling \"Rebuild client\"..."
+logProgress " * Profiling \"Rebuild client\"..."
 
 logMessage "==============================="
 logMessage "[Rebuild client]"
@@ -557,7 +557,7 @@ RebuildClientProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
-logProgress "Profiling \"Rebuild server\"..."
+logProgress " * Profiling \"Rebuild server\"..."
 
 logMessage "==============================="
 logMessage "[Rebuild server]"
@@ -578,7 +578,7 @@ killProcessByPort "${appPort}"
 sleep 2
 
 if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep -q "standard-minifier-js@"; then
-  logProgress "Profiling \"Visualize bundle\"..."
+  logProgress " * Profiling \"Visualize bundle\"..."
 
   logMessage "==============================="
   logMessage "[Visualize bundle]"

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+# app. Application directory name within ./apps/*
+# script. Artillery script name within ./artillery/*
+app="${1}"
+logName="${2}"
+if [[ -z "$app" ]]; then
+  echo "Usage: monitor-bundler.sh <app_name>"
+  exit 1;
+fi
+
+# Redirect stdout (1) and stderr (2) to a file
+logFile="logs/${logName}-${app}-bundle.log"
+mkdir -p logs
+exec > "./${logFile}" 2>&1
+
+# Initialize script constants
+baseDir="${PWD}"
+appsDir="${baseDir}/apps"
+appPath="${appsDir}/${app}"
+appPort=3000
+
+# Define color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Define helpers
+function getPidByName() {
+  ps aux | grep "${1}" | grep -v grep | awk '{print $2}'
+}
+
+function loadEnv() {
+  if [[ -f $1 ]]; then
+    # shellcheck disable=SC1090
+    source "${1}"
+    while read -r line; do
+      eval "export ${line}"
+    done <"$1"
+  fi
+}
+
+function formatToEnv() {
+  local str="${1}"
+  str=$(echo ${str} | sed -r -- 's/ /_/g')
+  str=$(echo ${str} | sed -r -- 's/\./_/g')
+  str=$(echo ${str} | sed -r -- 's/\-/_/g')
+  str=$(echo ${str} | tr -d "[@^\\\/<>\"'=]" | tr -d '*')
+  str=$(echo ${str} | sed -r -- 's/\//_/g')
+  str=$(echo ${str} | sed -r -- 's/,/_/g')
+  str=$(echo ${str} | sed 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/')
+  echo "${str}"
+}
+
+function isRunningUrl() {
+  local url="${1}"
+  local urlStatus="$(curl -Is "${url}" | head -1)"
+  echo "${urlStatus}" | grep -q "200"
+}
+
+function waitMeteorApp() {
+  PROCESS_WAIT_TIMEOUT=3600000
+  processWaitTimeoutSecs=$((PROCESS_WAIT_TIMEOUT / 1000))
+  waitSecs=0
+  while ! isRunningUrl "http://localhost:${appPort}" && [[ "${waitSecs}" -lt "${processWaitTimeoutSecs}" ]]; do
+    sleep 1
+    waitSecs=$((waitSecs + 1))
+  done
+}
+
+function startMeteorApp() {
+  if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
+    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" ${METEOR_CHECKOUT_PATH}/meteor run --port ${appPort} &
+  else
+    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor run --port ${appPort} &
+  fi
+}
+
+function logMeteorVersion() {
+  echo -e "==============================="
+  if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
+    local oldPath="${PWD}"
+    builtin cd "${METEOR_CHECKOUT_PATH}"
+    echo -e " Meteor checkout version - $(git rev-parse HEAD)"
+    builtin cd "${oldPath}"
+  else
+    echo -e " Meteor version - $(cat .meteor/release)"
+  fi
+  echo -e "==============================="
+}
+
+function findSecondPattern() {
+  local file="${1}"
+  local first_pattern="${2}"
+  local second_pattern="${3}"
+  # Search for the line containing the first pattern, then find the first occurrence of the second pattern after that line
+  awk '/'"${first_pattern}"'/ {found=1; next} found && /'"${second_pattern}"'/ {print; exit}' "${file}"
+}
+
+function parseNumberAndUnit() {
+  local input="$1"
+  echo "$input" | awk '{
+    for (i=1; i<=NF; i++) {
+      if ($i ~ /^[0-9,]+$/) {
+        gsub(",", "", $i); # Remove commas from the number
+        printf "%s %s", $i, $(i+1); # Correctly format the output
+        exit; # Ensure the loop stops after finding the first number and unit
+      }
+    }
+  }'
+}
+
+function findMetricStage() {
+  local stage="${1}"
+  local metric="${2}"
+  read num unit <<< $(parseNumberAndUnit "$(findSecondPattern "${baseDir}/${logFile}" "\[${stage}\]" "\(${metric}\)")")
+  echo -e " - ${metric}: ${num} ${unit}"
+}
+
+function getMetricsStage() {
+  local stage="${1}"
+  findMetricStage "${stage}" "ProjectContext resolveConstraints"
+  findMetricStage "${stage}" "ProjectContext prepareProjectForBuild"
+  findMetricStage "${stage}" "Build App"
+  findMetricStage "${stage}" "Server startup"
+}
+
+function reportStageMetrics() {
+  local stage="${1}"
+
+  echo -e "==============================="
+  echo -e "Metrics - ${stage}"
+  echo -e "==============================="
+
+  local metrics="$(getMetricsStage "${stage}")"
+  echo -e "${metrics}"
+
+  local totalNum=0
+  while IFS= read -r line; do
+    read num unit <<< $(parseNumberAndUnit "${line}")
+    ((totalNum += num))
+  done <<< "${metrics}"
+
+  echo -e " * Total: ${totalNum} ${unit}"
+}
+
+function reportMetrics() {
+  reportStageMetrics "Cold start"
+  reportStageMetrics "Cache start"
+}
+
+function killProcessByPort() {
+  local portToKill=${1:-''}
+  local portPid="$(lsof -i:"${portToKill}" -t)"
+  local killSignal=${2}
+
+  local cmdPrefix="$(echo "")"
+  for pid in $portPid; do
+    if [[ "${pid}" -eq "" ]]; then
+      return
+    fi
+
+    if [[ -z "${killSignal}" ]]; then
+      eval "${cmdPrefix} kill -9 \"${pid}\""
+    else
+      eval "${cmdPrefix} kill -s \"${killSignal}\" \"${pid}\""
+    fi
+  done
+}
+
+# Ensure proper cleanup on interrupt the process
+function cleanup() {
+    builtin cd ${baseDir};
+    pkill -P $$
+
+    sleep 2
+    reportMetrics
+
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+loadEnv "${baseDir}/.env"
+
+# Prepare, run and wait meteor app
+builtin cd "${appPath}"
+
+logMeteorVersion
+killProcessByPort "${appPort}"
+
+echo -e "==============================="
+echo -e "[Cold start]"
+echo -e "==============================="
+rm -rf "${appPath}/.meteor/local"
+startMeteorApp
+waitMeteorApp
+killProcessByPort "${appPort}"
+sleep 2
+
+echo -e "==============================="
+echo -e "[Cache start]"
+echo -e "==============================="
+startMeteorApp
+waitMeteorApp
+killProcessByPort "${appPort}"
+sleep 2
+
+cleanup

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -32,6 +32,11 @@ meteorClientEntrypoint="$(grep -oP '"client":\s*"\K[^"]+' "${appPath}/package.js
 meteorServerEntrypoint="$(grep -oP '"server":\s*"\K[^"]+' "${appPath}/package.json")"
 logFile="${logDir}/${logName}-${app}-bundle.log"
 
+meteorCmd="meteor"
+if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
+  meteorCmd="${METEOR_CHECKOUT_PATH}/meteor"
+fi
+
 # Redirect stdout (1) and stderr (2) to a file
 mkdir -p "${logDir}"
 # Save original stdout and stderr
@@ -128,11 +133,7 @@ function waitMeteorServerModified() {
 }
 
 function startMeteorApp() {
-  if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
-    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" ${METEOR_CHECKOUT_PATH}/meteor run --port ${appPort} ${meteorOptions} &
-  else
-    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor run --port ${appPort} ${meteorOptions} &
-  fi
+  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" ${meteorCmd} run --port ${appPort} ${meteorOptions} &
 }
 
 function logScriptInfo() {
@@ -164,13 +165,8 @@ function logNpmPackages() {
   echo -e "==============================="
   echo -e " Npm packages"
   echo -e "==============================="
-  if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
-    ${METEOR_CHECKOUT_PATH}/meteor node -p "Object.entries(Object.assign({}, require('${appPath}/package.json').dependencies, require('${appPath}/package.json').devDependencies)).map(([k,v]) => \`\${k}@\${v}\`).join('\n')" \
-      | awk '{ printf (NR%5 ? $0 " │ " : $0 "\n") } END { if (NR%5) print "" }'
-  else
-    meteor node -p "Object.entries(Object.assign({}, require('${appPath}/package.json').dependencies, require('${appPath}/package.json').devDependencies)).map(([k,v]) => \`\${k}@\${v}\`).join('\n')" \
-      | awk '{ printf (NR%5 ? $0 " │ " : $0 "\n") } END { if (NR%5) print "" }'
-  fi
+  $meteorCmd node -p "Object.entries(Object.assign({}, require('${appPath}/package.json').dependencies, require('${appPath}/package.json').devDependencies)).map(([k,v]) => \`\${k}@\${v}\`).join('\n')" \
+    | awk '{ printf (NR%5 ? $0 " │ " : $0 "\n") } END { if (NR%5) print "" }'
   echo -e "==============================="
 }
 

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -36,7 +36,7 @@ fi
 meteorClientEntrypoint="$(grep -oP '"client":\s*"\K[^"]+' "${appPath}/package.json")"
 meteorServerEntrypoint="$(grep -oP '"server":\s*"\K[^"]+' "${appPath}/package.json")"
 logFile="${logDir}/${logName}-${app}-bundle.log"
-monitorSize="${MONITOR_SIZE}"
+monitorSize="${METEOR_BUNDLE_SIZE}"
 
 meteorCmd="meteor"
 if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -536,7 +536,7 @@ logProgress " * Profiling \"Cold start\"..."
 logMessage "==============================="
 logMessage "[Cold start]"
 logMessage "==============================="
-rm -rf "${appPath}/.meteor/local"
+${meteorCmd} reset
 start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -33,8 +33,8 @@ if [[ -d "$appResolved" ]]; then
 else
   METEOR_PACKAGE_DIRS="${baseDir}/packages"
 fi
-meteorClientEntrypoint="$(grep -oP '"client":\s*"\K[^"]+' "${appPath}/package.json")"
-meteorServerEntrypoint="$(grep -oP '"server":\s*"\K[^"]+' "${appPath}/package.json")"
+meteorClientEntrypoint="$(sed -n 's/.*"client":\s*"\([^"]*\)".*/\1/p' "${appPath}/package.json")"
+meteorServerEntrypoint="$(sed -n 's/.*"server":\s*"\([^"]*\)".*/\1/p' "${appPath}/package.json")"
 logFile="${logDir}/${logName}-${app}-bundle.log"
 monitorSize="${METEOR_BUNDLE_SIZE}"
 
@@ -462,7 +462,7 @@ function triggerExit() {
   builtin cd ${baseDir};
 
   killProcessByPort "${appPort}"
-  kill -KILL -- -$$ >/dev/null
+  kill -KILL $(ps -o pgid= -p $$ | grep -o '[0-9]*') >/dev/null
 
   exit 1
 }

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -299,6 +299,18 @@ function formatCamelCase() {
   formatKebabCase "${str}" | sedr 's/(-)([a-z])/\U\2/g'
 }
 
+function isOSX() {
+  [[ "$OSTYPE" == "darwin"* ]]
+}
+
+function getTime() {
+  if isOSX; then
+    date +%s
+  else
+    date +%s%3N
+  fi
+}
+
 function findSecondPattern() {
   local file="${1}"
   local first_pattern="${2}"
@@ -526,10 +538,10 @@ logMessage "==============================="
 logMessage "[Cold start]"
 logMessage "==============================="
 rm -rf "${appPath}/.meteor/local"
-start_time_ms=$(date +%s%3N)
+start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp
-end_time_ms=$(date +%s%3N)
+end_time_ms=$(getTime)
 total_sleep_ms=1000 # sleep leftovers
 ColdStartProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
@@ -540,10 +552,10 @@ logProgress " * Profiling \"Cache start\"..."
 logMessage "==============================="
 logMessage "[Cache start]"
 logMessage "==============================="
-start_time_ms=$(date +%s%3N)
+start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp
-end_time_ms=$(date +%s%3N)
+end_time_ms=$(getTime)
 total_sleep_ms=1000 # sleep leftovers
 CacheStartProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
@@ -555,7 +567,7 @@ logMessage "==============================="
 logMessage "[Rebuild client]"
 logMessage "==============================="
 logMessage "Client entrypoint: ${meteorClientEntrypoint}"
-start_time_ms=$(date +%s%3N)
+start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp
 appendLine "console.log('new line')" "${meteorClientEntrypoint}"
@@ -564,7 +576,7 @@ waitMeteorApp
 removeLastLine "${meteorClientEntrypoint}"
 waitMeteorClientModified "#2"
 waitMeteorApp
-end_time_ms=$(date +%s%3N)
+end_time_ms=$(getTime)
 total_sleep_ms=5000 # sleep leftovers
 RebuildClientProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
@@ -576,7 +588,7 @@ logMessage "==============================="
 logMessage "[Rebuild server]"
 logMessage "==============================="
 logMessage "Server entrypoint: ${meteorServerEntrypoint}"
-start_time_ms=$(date +%s%3N)
+start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp
 appendLine "console.log('new line')" "${meteorServerEntrypoint}"
@@ -585,7 +597,7 @@ waitMeteorApp
 removeLastLine "${meteorServerEntrypoint}"
 waitMeteorServerModified "#2"
 waitMeteorApp
-end_time_ms=$(date +%s%3N)
+end_time_ms=$(getTime)
 total_sleep_ms=5000 # sleep leftovers
 RebuildServerProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
 killProcessByPort "${appPort}"
@@ -597,11 +609,11 @@ if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep 
   logMessage "==============================="
   logMessage "[Visualize bundle]"
   logMessage "==============================="
-  start_time_ms=$(date +%s%3N)
+  start_time_ms=$(getTime)
   visualizeMeteorAppBundle
   waitMeteorApp
   BundleSize=$(calculateMeteorAppBundleSize)
-  end_time_ms=$(date +%s%3N)
+  end_time_ms=$(getTime)
   total_sleep_ms=1000 # sleep leftovers
   VisualizeBundleProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
   killProcessByPort "${appPort}"

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -133,7 +133,10 @@ function waitMeteorServerModified() {
 }
 
 function startMeteorApp() {
-  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" ${meteorCmd} run --port ${appPort} ${meteorOptions} &
+  if [[ -z "${METEOR_PACKAGE_DIRS}" ]]; then
+    METEOR_PACKAGE_DIRS="${baseDir}/packages"
+  fi
+  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} run --port ${appPort} ${meteorOptions} &
 }
 
 function logScriptInfo() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -94,11 +94,11 @@ function logScriptInfo() {
   logBanner "==============================="
   logBanner " Profile script"
   logBanner "==============================="
-  logMessage " - App path: $(logMessage "${appPath}")"
-  logMessage " - App port: $(logMessage "${appPort}")"
-  logMessage " - Logs file: $(logMessage "${logFile}")"
+  logBanner " - App path: $(logMessage "${appPath}")"
+  logBanner " - App port: $(logMessage "${appPort}")"
+  logBanner " - Logs file: $(logMessage "${logFile}")"
   if [[ "${monitorSize}" == "true" ]]; then
-  logMessage " - Monitor size: $(logMessage "${monitorSize}")"
+  logBanner " - Monitor size: $(logMessage "${monitorSize}")"
   fi
   logBanner "==============================="
 }

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -43,12 +43,25 @@ if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
   meteorCmd="${METEOR_CHECKOUT_PATH}/meteor"
 fi
 
+function logScriptInfo() {
+  echo -e "==============================="
+  echo -e " Script"
+  echo -e " - App path: ${appPath}"
+  echo -e " - App port: ${appPort}"
+  echo -e " - Logs file: ${logFile}"
+  if [[ "${monitorSize}" == "true" ]]; then
+  echo -e " - Monitor size: ${monitorSize}"
+  fi
+  echo -e "==============================="
+}
+
 function logFullLogDetails() {
   echo -e "==============================="
   echo -e " Full log details at ${logFile}"
   echo -e "==============================="
 }
 
+logScriptInfo
 logFullLogDetails
 
 # Redirect stdout (1) and stderr (2) to a file
@@ -160,18 +173,6 @@ function removeMeteorAppBundleVisualizer() {
 
 function calculateMeteorAppBundleSize() {
   MONITOR_SIZE_URL="http://localhost:${appPort}/__meteor__/bundle-visualizer/stats" ${meteorCmd} node $(dirname $0)/helpers/print-bundle-size.js
-}
-
-function logScriptInfo() {
-  echo -e "==============================="
-  echo -e " Script"
-  echo -e " - App path: ${appPath}"
-  echo -e " - App port: ${appPort}"
-  echo -e " - Logs file: ${logFile}"
-  if [[ "${monitorSize}" == "true" ]]; then
-  echo -e " - Monitor size: ${monitorSize}"
-  fi
-  echo -e "==============================="
 }
 
 function logMeteorVersion() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -520,7 +520,7 @@ meteorServerEntrypoint="$(runScriptHelper "get-meteor-entrypoint.js" "${appPath}
 
 loadEnv "${baseDir}/.env"
 
-monitorErrorsAndTimeout "${logFile}" 2 60 &
+monitorErrorsAndTimeout "${logFile}" 2 ${METEOR_IDLE_TIMEOUT:-90} &
 
 # Prepare, run and wait meteor app
 builtin cd "${appPath}"

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -43,6 +43,14 @@ if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
   meteorCmd="${METEOR_CHECKOUT_PATH}/meteor"
 fi
 
+function logFullLogDetails() {
+  echo -e "==============================="
+  echo -e " Full log details at ${logFile}"
+  echo -e "==============================="
+}
+
+logFullLogDetails
+
 # Redirect stdout (1) and stderr (2) to a file
 mkdir -p "${logDir}"
 # Save original stdout and stderr
@@ -368,6 +376,7 @@ function cleanup() {
   logMeteorPackages
   logMeteorVersion
   reportMetrics
+  logFullLogDetails
 
   # Close the saved file descriptors
   exec 3>&- 4>&-

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -474,6 +474,8 @@ function cleanup() {
 
   sleep 2
 
+  logMessage
+
   DISABLE_COLORS=true logScriptInfo
   DISABLE_COLORS=true logNpmPackages
   DISABLE_COLORS=true logMeteorPackages

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -119,19 +119,26 @@ function startMeteorApp() {
 
 function logMeteorVersion() {
   echo -e "==============================="
+  echo -e " Meteor version - $(cat "${appPath}/.meteor/release")"
   if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
     local oldPath="${PWD}"
     builtin cd "${METEOR_CHECKOUT_PATH}"
     echo -e " Meteor checkout version - $(git rev-parse HEAD)"
     builtin cd "${oldPath}"
-  else
-    echo -e " Meteor version - $(cat .meteor/release)"
   fi
   echo -e "==============================="
   if [[ -n "${meteorOptions}" ]]; then
     echo -e " Meteor options - ${meteorOptions}"
     echo -e "==============================="
   fi
+}
+
+function logMeteorPackages() {
+  echo -e "==============================="
+  echo -e " Meteor packages"
+  echo -e "==============================="
+  echo -e " $(formatFile "${appPath}/.meteor/versions")"
+  echo -e "==============================="
 }
 
 function sedr() {
@@ -265,15 +272,22 @@ function removeLastLine() {
     sed -i '$ d' "$1"
 }
 
+function formatFile() {
+   [[ -f "$1" ]] || { echo "File not found: $1"; return 1; }
+   awk '{ printf (NR%5 ? $0 " │ " : $0 "\n") } END { if (NR%5) print "" }' "$1"
+}
+
 # Ensure proper cleanup on interrupt the process
 function cleanup() {
-    builtin cd ${baseDir};
-    pkill -P $$
+  builtin cd ${baseDir};
+  pkill -P $$
 
-    sleep 2
-    reportMetrics
+  sleep 2
+  logMeteorVersion
+  reportMetrics
+  logMeteorPackages
 
-    exit 0
+  exit 0
 }
 trap cleanup SIGINT SIGTERM
 

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -4,6 +4,7 @@
 # script. Artillery script name within ./artillery/*
 app="${1}"
 logName="${2}"
+meteorOptions="${@:3}"
 if [[ -z "$app" ]]; then
   echo "Usage: monitor-bundler.sh <app_name>"
   exit 1;
@@ -70,9 +71,9 @@ function waitMeteorApp() {
 
 function startMeteorApp() {
   if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
-    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" ${METEOR_CHECKOUT_PATH}/meteor run --port ${appPort} &
+    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" ${METEOR_CHECKOUT_PATH}/meteor run --port ${appPort} ${meteorOptions} &
   else
-    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor run --port ${appPort} &
+    METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${baseDir}/packages" meteor run --port ${appPort} ${meteorOptions} &
   fi
 }
 
@@ -87,6 +88,10 @@ function logMeteorVersion() {
     echo -e " Meteor version - $(cat .meteor/release)"
   fi
   echo -e "==============================="
+  if [[ -n "${meteorOptions}" ]]; then
+    echo -e " Meteor options - ${meteorOptions}"
+    echo -e "==============================="
+  fi
 }
 
 function sedr() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -372,7 +372,6 @@ function cleanup() {
   # Restore original stdout and stderr
   exec 1>&3 2>&4
 
-  logScriptInfo
   logNpmPackages
   logMeteorPackages
   logMeteorVersion

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -30,6 +30,8 @@ if [[ -d "$appResolved" ]]; then
   appPath="${appsDir}/${app}"
   logDir="${appPath}/logs"
   logFile="${logDir}/${logName}-${app}-bundle.log"
+else
+  METEOR_PACKAGE_DIRS="${baseDir}/packages"
 fi
 meteorClientEntrypoint="$(grep -oP '"client":\s*"\K[^"]+' "${appPath}/package.json")"
 meteorServerEntrypoint="$(grep -oP '"server":\s*"\K[^"]+' "${appPath}/package.json")"
@@ -136,9 +138,6 @@ function waitMeteorServerModified() {
 }
 
 function startMeteorApp() {
-  if [[ -z "${METEOR_PACKAGE_DIRS}" ]]; then
-    METEOR_PACKAGE_DIRS="${baseDir}/packages"
-  fi
   METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} run ${meteorOptions} &
 }
 

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -281,22 +281,8 @@ function sedr() {
   sed -r -- "$@"
 }
 
-function formatKebabCase() {
-  local str="${1}"
-  str=$(echo ${str} | sedr 's/([A-Z])/-\1/g')
-  str=$(echo ${str} | sedr 's/ /-/g')
-  str=$(echo ${str} | sedr 's/@/-/g')
-  str=$(echo ${str} | sedr 's/\//-/g')
-  str=$(echo ${str} | sedr 's/:/-/g')
-  str=$(echo ${str} | sedr 's/\./-/g')
-  str=$(echo ${str} | sedr 's/_/-/g')
-  str=$(echo ${str} | sedr 's/-+/-/g')
-  echo "${str}" | tr '[:upper:]' '[:lower:]'
-}
-
-function formatCamelCase() {
-  local str="${1}"
-  formatKebabCase "${str}" | sedr 's/(-)([a-z])/\U\2/g'
+function formatEnvCase() {
+  ${meteorCmd} node -e "console.log(\"${1}\".replace(/\s+(.)/g, (match, group1) => group1.toUpperCase()).replace(/\s+/g, ''))"
 }
 
 function isOSX() {
@@ -383,7 +369,7 @@ function reportStageMetrics() {
   done <<< "${metrics}"
 
   logMessage " * Total: ${totalNum} ${unit}"
-  logMessage " * Total Process: $(eval "echo \${$(formatCamelCase "${stage}ProcessTime")}") ms"
+  logMessage " * Total Process: $(eval "echo \${$(formatEnvCase "${stage}ProcessTime")}") ms"
 }
 
 function reportMetrics() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -14,7 +14,10 @@ fi
 baseDir="${PWD}"
 appsDir="${baseDir}/apps"
 appPath="${appsDir}/${app}"
-appPort=3000
+appPort="$(echo "$meteorOptions" | sed -n 's/.*--port[ =]\?\([0-9]\+\).*/\1/p')"
+if [[ -z "$appPort" ]]; then
+  appPort=3000
+fi
 appResolved="$(echo $app)"
 logDir="${baseDir}/logs"
 if [[ -d "$appResolved" ]]; then
@@ -136,7 +139,7 @@ function startMeteorApp() {
   if [[ -z "${METEOR_PACKAGE_DIRS}" ]]; then
     METEOR_PACKAGE_DIRS="${baseDir}/packages"
   fi
-  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} run --port ${appPort} ${meteorOptions} &
+  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} run ${meteorOptions} &
 }
 
 function logScriptInfo() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -379,8 +379,8 @@ function reportStageMetrics() {
     ((totalNum += num))
   done <<< "${metrics}"
 
-  logMessage " * Total: ${totalNum} ${unit}"
-  logMessage " * Total Process: $(eval "echo \${$(formatEnvCase "${stage}ProcessTime")}") ms"
+  logMessage " * Total(Meteor): ${totalNum} ${unit}"
+  # logMessage " * Total Process: $(eval "echo \${$(formatEnvCase "${stage}ProcessTime")}") ms"
 }
 
 function reportMetrics() {
@@ -541,8 +541,7 @@ start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp
 end_time_ms=$(getTime)
-total_sleep_ms=1000 # sleep leftovers
-ColdStartProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
+ColdStartProcessTime=$((end_time_ms - start_time_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
@@ -555,8 +554,7 @@ start_time_ms=$(getTime)
 startMeteorApp
 waitMeteorApp
 end_time_ms=$(getTime)
-total_sleep_ms=1000 # sleep leftovers
-CacheStartProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
+CacheStartProcessTime=$((end_time_ms - start_time_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
@@ -576,8 +574,7 @@ removeLastLine "${meteorClientEntrypoint}"
 waitMeteorClientModified "#2"
 waitMeteorApp
 end_time_ms=$(getTime)
-total_sleep_ms=5000 # sleep leftovers
-RebuildClientProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
+RebuildClientProcessTime=$((end_time_ms - start_time_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
@@ -597,8 +594,7 @@ removeLastLine "${meteorServerEntrypoint}"
 waitMeteorServerModified "#2"
 waitMeteorApp
 end_time_ms=$(getTime)
-total_sleep_ms=5000 # sleep leftovers
-RebuildServerProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
+RebuildServerProcessTime=$((end_time_ms - start_time_ms))
 killProcessByPort "${appPort}"
 sleep 2
 
@@ -613,8 +609,7 @@ if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep 
   waitMeteorApp
   BundleSize=$(calculateMeteorAppBundleSize)
   end_time_ms=$(getTime)
-  total_sleep_ms=1000 # sleep leftovers
-  VisualizeBundleProcessTime=$((end_time_ms - start_time_ms - total_sleep_ms))
+  VisualizeBundleProcessTime=$((end_time_ms - start_time_ms))
   killProcessByPort "${appPort}"
   sleep 2
   removeMeteorAppBundleVisualizer

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -226,11 +226,11 @@ function waitMeteorServerModified() {
 }
 
 function startMeteorApp() {
-  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} run ${meteorOptions} &
+  METEOR_PROFILE="${METEOR_PROFILE:-1}}" METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} run ${meteorOptions} &
 }
 
 function visualizeMeteorAppBundle() {
-  METEOR_PROFILE=1 METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} --extra-packages bundle-visualizer --production ${meteorOptions} &
+  METEOR_PROFILE="${METEOR_PROFILE:-1}}" METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} --extra-packages bundle-visualizer --production ${meteorOptions} &
 }
 
 function removeMeteorAppBundleVisualizer() {

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -151,7 +151,7 @@ function removeMeteorAppBundleVisualizer() {
 }
 
 function calculateMeteorAppBundleSize() {
-  MONITOR_SIZE_URL="http://localhost:${appPort}/__meteor__/bundle-visualizer/stats" ${meteorCmd} node ${baseDir}/scripts/helpers/print-bundle-size.js
+  MONITOR_SIZE_URL="http://localhost:${appPort}/__meteor__/bundle-visualizer/stats" ${meteorCmd} node $(dirname $0)/helpers/print-bundle-size.js
 }
 
 function logScriptInfo() {


### PR DESCRIPTION
<!---OSS-665--->

This PR adds a new script monitor to track bundler performance and compare versions to identify improvements or regressions. It also lays the groundwork for refining bundler options to ensure all changes lead to better outcomes.

The script outputs metrics from the processes it monitors, such as:

![image](https://github.com/user-attachments/assets/0dfd3979-8b1d-4039-9215-717b2d924d27)

> This example image shows the build times of Meteor 3.1.1 when targeting all architectures versus only modern ones. (apps/tasks-3.x app)

![image](https://github.com/user-attachments/assets/84a235af-e7b5-45bd-8666-af562ee65e19)

> This example image shows the build times of Meteor 2.16 when targeting all architectures versus only modern ones. (apps/tasks-2.x app)

## Machine specs

Intel Core Raptor Lake i9 13900K
64 RAM DDR5 6000 MHz CL30
SSD WD Black SN850X

## Pending

- [x] Monitor cold start metric (`meteor run`)
- [x] Monitor cache start metric (`meteor run`)
- [x] Monitor app file change rebuild metric (two runs) (`meteor run`)
- [x] Monitor package file change rebuild metric (two runs) (`meteor run`)
- [x] Ensure getting profiles from a Meteor checkout

Later, we´ll also grab metrics from other external bundler, like webpack.

# Later enhancements

- [x] The ResolveConstraint and prepareProjectForBuild phases don't show time in the output. This could mean that Meteor 3.x runs these tasks in parallel without blocking the build process, unlike Meteor 2.x. Alternatively, it might indicate an issue that needs to be fixed. Fixed: https://github.com/meteor/meteor/pull/13628
- [x] `meteor benchmark` command to automatically run the script on any Meteor app project and get the metrics.
- [ ] Monitor `meteor build` process
- [ ] New two apps per Meteor version having a deep structure of mock files (based https://github.com/web-infra-dev/bundler-benchmark/tree/main/cases/rc-1000)