### PR TITLE
adding inspector context

### DIFF
--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -566,6 +566,7 @@ if [[ "${monitorSizeOnly}" != "true" ]]; then
   logMessage "==============================="
   ${meteorCmd} reset --skip-cache
   start_time_ms=$(getTime)
+  export METEOR_INSPECT_CONTEXT="cold-start"
   startMeteorApp
   waitMeteorApp
   end_time_ms=$(getTime)
@@ -579,6 +580,7 @@ if [[ "${monitorSizeOnly}" != "true" ]]; then
   logMessage "[Cache start]"
   logMessage "==============================="
   start_time_ms=$(getTime)
+  export METEOR_INSPECT_CONTEXT="cache-start"
   startMeteorApp
   waitMeteorApp
   end_time_ms=$(getTime)
@@ -593,6 +595,7 @@ if [[ "${monitorSizeOnly}" != "true" ]]; then
   logMessage "==============================="
   logMessage "Client entrypoint: ${meteorClientEntrypoint}"
   start_time_ms=$(getTime)
+  export METEOR_INSPECT_CONTEXT="rebuild-client"
   startMeteorApp
   waitMeteorApp
   appendLine "console.log('new line')" "${meteorClientEntrypoint}"
@@ -613,6 +616,7 @@ if [[ "${monitorSizeOnly}" != "true" ]]; then
   logMessage "==============================="
   logMessage "Server entrypoint: ${meteorServerEntrypoint}"
   start_time_ms=$(getTime)
+  export METEOR_INSPECT_CONTEXT="rebuild-server"
   startMeteorApp
   waitMeteorApp
   appendLine "console.log('new line')" "${meteorServerEntrypoint}"
@@ -634,6 +638,7 @@ if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep 
   logMessage "[Visualize bundle]"
   logMessage "==============================="
   start_time_ms=$(getTime)
+  export METEOR_INSPECT_CONTEXT="visualize-bundle"
   visualizeMeteorAppBundle
   waitMeteorApp
   BundleSize=$(calculateMeteorAppBundleSize)
@@ -644,4 +649,4 @@ if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep 
   removeMeteorAppBundleVisualizer
 fi
 
-cleanup
+cleanup 


### PR DESCRIPTION
Meteor's cpuprofile uses the METEOR_CONTEXT to compose the output files, following it, I added this envs for each step into `monitor-bundler.sh`

<img width="423" alt="Screenshot 2025-03-28 at 14 37 04" src="https://github.com/user-attachments/assets/bae9ddfe-7e3c-424e-a82b-f582941e2d47" />

