### PR TITLE
Support profiling "meteor build"

### DIFF
--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -92,7 +92,7 @@ function logProgress() {
 }
 
 function logBanner() {
-  if [[ "${DISABLE_COLORS}" == "true" ]]; then
+  if [[ -n "${DISABLE_COLORS}" ]]; then
     logMessage "${1}"
     return
   fi
@@ -100,7 +100,7 @@ function logBanner() {
 }
 
 function logSpecial() {
-  if [[ "${DISABLE_COLORS}" == "true" ]]; then
+  if [[ -n "${DISABLE_COLORS}" ]]; then
     logMessage "${1}"
     return
   fi
@@ -108,7 +108,7 @@ function logSpecial() {
 }
 
 function logError() {
-  if [[ "${DISABLE_COLORS}" == "true" ]]; then
+  if [[ -n "${DISABLE_COLORS}" ]]; then
     logMessage "${1}"
     return
   fi
@@ -122,7 +122,7 @@ function logScriptInfo() {
   logBanner " - App path: $(logMessage "${appPath}")"
   logBanner " - App port: $(logMessage "${appPort}")"
   logBanner " - Logs file: $(logMessage "${logFile}")"
-  if [[ "${monitorSize}" == "true" ]]; then
+  if [[ -n "${monitorSize}" ]]; then
   logBanner " - Monitor size: $(logMessage "${monitorSize}")"
   fi
   logBanner "==============================="
@@ -395,21 +395,21 @@ function reportStageMetrics() {
   done <<< "${metrics}"
 
   logMessage " * Total(Meteor): ${totalNum} ${unit}"
-  if [[ -n "${METEOR_MONITOR_PROCESS}" ]] && [[ "${METEOR_MONITOR_PROCESS}" == "true" ]]; then
+  if [[ -n "${METEOR_MONITOR_PROCESS}" ]]; then
     local totalProcess="$(eval "echo \${$(formatEnvCase "${stage}ProcessTime")}")"
     logMessage " * Total(Process): ${totalProcess} ms (+$((totalProcess - totalNum)) ms)"
   fi
 }
 
 function reportMetrics() {
-  if [[ "${monitorSizeOnly}" != "true" ]]; then
+  if [[ -z "${monitorSizeOnly}" ]]; then
     reportStageMetrics "Cold start"
     reportStageMetrics "Cache start"
     reportStageMetrics "Rebuild client"
     reportStageMetrics "Rebuild server"
   fi
 
-  if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep -q "standard-minifier-js@"; then
+  if [[ -n "${monitorSize}" ]] && cat "${appPath}/.meteor/versions" | grep -q "standard-minifier-js@"; then
     reportStageMetrics "Visualize bundle"
     logMeteorBundleSize
   fi
@@ -538,7 +538,7 @@ trap cleanup SIGINT SIGTERM
 meteorClientEntrypoint="${METEOR_CLIENT_ENTRYPOINT:-$(runScriptHelper "get-meteor-entrypoint.js" "${appPath}" "client")}"
 meteorServerEntrypoint="${METEOR_SERVER_ENTRYPOINT:-$(runScriptHelper "get-meteor-entrypoint.js" "${appPath}" "server")}"
 
-if [[ "${monitorSizeOnly}" != "true" ]] && ([[ -z "${meteorClientEntrypoint}" ]] || [[ -z "${meteorServerEntrypoint}" ]]); then
+if [[ -z "${monitorSizeOnly}" ]] && ([[ -z "${meteorClientEntrypoint}" ]] || [[ -z "${meteorServerEntrypoint}" ]]); then
   # Restore original stdout and stderr
   exec 1>&3 2>&4
 
@@ -566,7 +566,7 @@ logMessage "Node cmd: $(getMeteorNodeCmd)"
 
 killProcessByPort "${appPort}"
 
-if [[ "${monitorSizeOnly}" != "true" ]]; then
+if [[ -z "${monitorSizeOnly}" ]]; then
   logProgress " * Profiling \"Cold start\"..."
 
   logMessage "==============================="
@@ -639,7 +639,7 @@ if [[ "${monitorSizeOnly}" != "true" ]]; then
   sleep 2
 fi
 
-if [[ "${monitorSize}" == "true" ]] && cat "${appPath}/.meteor/versions" | grep -q "standard-minifier-js@"; then
+if [[ -n "${monitorSize}" ]] && cat "${appPath}/.meteor/versions" | grep -q "standard-minifier-js@"; then
   logProgress " * Profiling \"Visualize bundle\"..."
 
   logMessage "==============================="

--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -49,6 +49,7 @@ monitorSize="${METEOR_BUNDLE_SIZE:-${METEOR_BUNDLE_SIZE_ONLY}}"
 monitorSizeOnly="${METEOR_BUNDLE_SIZE_ONLY}"
 
 monitorBuild="${METEOR_BUNDLE_BUILD}"
+buildDirectory="/tmp/${logName}-${app}-dist"
 
 meteorCmd="meteor"
 if [[ -n "${METEOR_CHECKOUT_PATH}" ]]; then
@@ -243,7 +244,7 @@ function startMeteorApp() {
 }
 
 function buildMeteorApp() {
-  METEOR_PROFILE="${METEOR_PROFILE:-1}}" METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} build --directory /tmp/build ${meteorOptions}
+  METEOR_PROFILE="${METEOR_PROFILE:-1}}" METEOR_PACKAGE_DIRS="${METEOR_PACKAGE_DIRS}" ${meteorCmd} build --directory "${buildDirectory}" ${meteorOptions}
 }
 
 function visualizeMeteorAppBundle() {
@@ -674,8 +675,8 @@ if [[ -n "${monitorBuild}" ]]; then
   buildMeteorApp
   end_time_ms=$(getTime)
   ColdBuildProcessTime=$((end_time_ms - start_time_ms))
-  killProcessByPort "${appPort}"
-  sleep 2
+  rm -rf "${buildDirectory}"
+  sleep 1
 
   logProgress " * Profiling \"Cache build\"..."
 
@@ -687,8 +688,8 @@ if [[ -n "${monitorBuild}" ]]; then
   buildMeteorApp
   end_time_ms=$(getTime)
   CacheBuildProcessTime=$((end_time_ms - start_time_ms))
-  killProcessByPort "${appPort}"
-  sleep 2
+  rm -rf "${buildDirectory}"
+  sleep 1
 
  logProgress " * Profiling \"Final build\"..."
 
@@ -700,8 +701,8 @@ if [[ -n "${monitorBuild}" ]]; then
   buildMeteorApp
   end_time_ms=$(getTime)
   FinalBuildProcessTime=$((end_time_ms - start_time_ms))
-  killProcessByPort "${appPort}"
-  sleep 2
+  rm -rf "${buildDirectory}"
+  sleep 1
 fi
 
 if [[ -n "${monitorSize}" ]] && cat "${appPath}/.meteor/versions" | grep -q "standard-minifier-js@"; then


### PR DESCRIPTION
This PR introduces support of profiling `meteor build` process that is the process to build the artifacts for production. Important command that also influences deploy. I will enable it for `meteor profile --build` option to the next 3.3 release.

![image](https://github.com/user-attachments/assets/52b3c786-0e41-4522-ae4e-ac488c3acc7b)
