### PR TITLE
Fix issue on global absolute paths

### DIFF
--- a/scripts/monitor-bundler.sh
+++ b/scripts/monitor-bundler.sh
@@ -21,7 +21,7 @@ fi
 appResolved="$(echo $app)"
 logDir="${baseDir}/logs"
 if [[ -d "$appResolved" ]]; then
-  if [[ "$appResolved" == "$(echo ~)/"* ]]; then
+  if [[ "$appResolved" == "$(echo ~)/"* ]] || [[ "$appResolved" == "/"* ]]; then
     appsDir="$(dirname $appResolved)"
   else
     appsDir="${baseDir}/$(dirname $appResolved)"


### PR DESCRIPTION
<!-- OSS-800 -->

This PR fixes an issue where `meteor profile` did not work correctly for paths outside the home context.